### PR TITLE
fix: reset ssh session

### DIFF
--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -70,6 +70,10 @@
     groups: docker
     append: true
 
+- name: Reset ssh connection to apply group changes
+  ansible.builtin.meta:
+    reset_connection
+
 - name: Verify Docker installation
   ansible.builtin.command: docker --version
   register: docker_version


### PR DESCRIPTION
## Changes summary

Resets SSH session, so that adding user to `docker` group has immediate effect.

Fixes issue, where `docker-compose up` failed.
