### PR TITLE
fix: fix reverse proxy

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -4,8 +4,6 @@ services:
     image: europe-central2-docker.pkg.dev/eficode-recruitment-2024/containers/backend:latest
     build: ./backend
     init: true
-    ports:
-      - ${BACKEND_PORT}:${BACKEND_PORT}
     env_file:
       - .env
     environment:
@@ -23,9 +21,3 @@ services:
     ports:
       - 80:80
       - 443:443
-    env_file:
-      - .env
-    environment:
-      - PORT=${FRONTEND_PORT}
-      - HOST=${FRONTEND_HOST}
-      - BACKEND_URL=${FRONTEND_ENDPOINT}

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,5 +1,6 @@
 services:
   backend:
+    container_name: eficode-backend
     image: europe-central2-docker.pkg.dev/eficode-recruitment-2024/containers/backend:latest
     build: ./backend
     init: true
@@ -8,7 +9,7 @@ services:
     env_file:
       - .env
     environment:
-      - PORT=${BACKEND_PORT}
+      - PORT=9000
       - APPID=${OPENWEATHER_API_KEY}
       - MAP_ENDPOINT=${OPENWEATHER_MAP_ENDPOINT}
       - TARGET_CITY=${OPENWEATHER_TARGET_CITY}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
     environment:
       - PORT=${FRONTEND_PORT}
       - HOST=${FRONTEND_HOST}
-      - BACKEND_URL=${FRONTEND_ENDPOINT}
+      - FRONTEND_ENDPOINT=${FRONTEND_ENDPOINT}
     develop:
       watch:
         - path: frontend/

--- a/frontend/docker/prod/Caddyfile
+++ b/frontend/docker/prod/Caddyfile
@@ -6,7 +6,7 @@
   encode gzip
 
 	handle /api* {
-		reverse_proxy localhost:9000
+		reverse_proxy eficode-backend:9000
 	}
 
 	handle {

--- a/frontend/docker/prod/Dockerfile
+++ b/frontend/docker/prod/Dockerfile
@@ -4,10 +4,10 @@ WORKDIR /usr/src/app
 
 COPY frontend/package*.json ./
 RUN npm install
-COPY ./.env ../
 COPY frontend ./
 
-RUN npm run build
+# Sets the environment variable just for the build
+RUN FRONTEND_ENDPOINT=/api npm run build
 
 
 FROM caddy:2.8.4


### PR DESCRIPTION
## Changes summary

- Caddy correctly reverse proxies to the backend container,
- Backend is no longer exposed on port 9000 on production,
- Removes environment section from frontend's compose, as it doesn't take effect in build.


